### PR TITLE
the DisplayName element in the list-bucket-result seems optional

### DIFF
--- a/bucket-listing.lisp
+++ b/bucket-listing.lisp
@@ -87,7 +87,7 @@
               (optional
                ("Owner"
                 ("ID" (bind :owner-id))
-                ("DisplayName" (bind :owner-display-name))))
+                (optional ("DisplayName" (bind :owner-display-name)))))
               ("StorageClass" (bind :storage-class))))
    (sequence :common-prefixes
              ("CommonPrefixes"


### PR DESCRIPTION
I tested it with Amazon S3 and got a response with no DisplayName
element, which broker parsing the response