### PR TITLE
Add support for streams to put-object.

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1424,6 +1424,9 @@ bucket with the given name.
     <p>If <i>object</i> is a pathname, its contents are loaded in
     memory as an octet vector and stored.
 
+    <p>If <i>object</i> is a stream, everything that can be read
+    from the stream until EOF will be stored.
+
     <p>If provided, <var>access-policy</var> should be one of the
     following:
 

--- a/interface.lisp
+++ b/interface.lisp
@@ -379,7 +379,7 @@ constraint."
             (flexi-streams:string-to-octets object
                                             :external-format
                                             string-external-format))
-           ((or vector pathname) object)))
+           ((or vector pathname stream) object)))
         (content-length t)
         (policy-header (access-policy-header access-policy public))
         (security-token (security-token *credentials*)))


### PR DESCRIPTION
This lets the caller define memory-unbounded inputs to send to s3. The
typical use case being reading from a socket and streaming to s3.

Note that put-stream is not adding support for this because
FLEXI-STREAMS does not support embedding a stream with `start` and
`end` parameters.