### PR TITLE
Update puri URLs to use kpe.io

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -54,8 +54,8 @@ The latest version is 1.3.3, released on September 29th, 2019.
      <li> <a href="http://common-lisp.net/project/cxml/">Closure XML</a>
      <li> <a href="http://weitz.de/drakma/">Drakma</a> <b>1.0.0 or newer</b>
      <li> <a href="http://method-combination.net/lisp/ironclad/">Ironclad</a>
-     <li> <a href="http://files.b9.com/cl-base64/">cl-base64</a>
-     <li> <a href="http://puri.b9.com/">Puri</a>
+     <li> <a href="http://files.kpe.io/cl-base64/">cl-base64</a>
+     <li> <a href="http://files.kpe.io/puri/">Puri</a>
    </ul>
 
  <p>The easiest way to install ZS3 and all its required libraries is
@@ -243,7 +243,7 @@ interface. Some features are unsupported or incompletely supported:
 
     <li> If a character in a key is encoded with multiple bytes in
       UTF-8, a bad interaction
-      between <a href="http://puri.b9.com/">PURI</a> and Amazon's web
+      between <a href="http://files.kpe.io/puri/">PURI</a> and Amazon's web
       servers will trigger a validation error.
 
   </ul>


### PR DESCRIPTION
b9.com is defunct. Use these links provided in the PURI README.