### PR TITLE
Update to new bucket format

### DIFF
--- a/interface.lisp
+++ b/interface.lisp
@@ -150,9 +150,7 @@ constraint."
 (defun bucket-exists-p (bucket &key
                                  ((:credentials *credentials*) *credentials*)
                                  ((:backoff *backoff*) *backoff*))
-  (let ((code (nth-value 1 (head :bucket bucket
-                                 :parameters
-                                 (parameters-alist :max-keys 0)))))
+  (let ((code (nth-value 1 (head :bucket bucket))))
     (not (<= 400 code 599))))
 
 (defun create-bucket (name &key

--- a/request.lisp
+++ b/request.lisp
@@ -190,11 +190,10 @@
                                        &rest initargs &key
                                        &allow-other-keys)
   (declare (ignore initargs))
-  (when (eql (method request) :head)
-    ;; https://forums.aws.amazon.com/thread.jspa?messageID=340398 -
-    ;; when using the bare endpoint, the 301 redirect for a HEAD
-    ;; request does not include enough info to actually redirect. Use
-    ;; the bucket endpoint pre-emptively instead
+  (when (bucket request)
+    ;; Always use virtual-hosted style for all bucket operations.
+    ;; Path-style access is blocked by AWS for buckets created after Sep 30, 2020.
+    ;; Virtual-hosted style: https://bucket.s3.region.amazonaws.com/key
     (setf (endpoint request) (format nil "~A.~A"
                                      (bucket request)
                                      *s3-endpoint*)))


### PR DESCRIPTION
I was playing with using this with s3, and I needed to make this change to support the bucket format introduced in 2020 and all new buckets use by default since then.